### PR TITLE
feat: Add MA1 rozstrely, update KaTeX to process brackets

### DIFF
--- a/questions/ma1/questions/11899049/question.json
+++ b/questions/ma1/questions/11899049/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Která z následujících tvrzení představují postačující podmínky pro existenci inverzní funkce k funkci \\(f\\) ?",
+    "answers": [
+        {
+            "text": "Funkce \\(f\\) je ryze monotónní.",
+            "isCorrect": true
+        },
+        {
+            "text": "Obor hodnot funkce \\(f\\) je množina \\(\\mathbb{R}\\).",
+            "isCorrect": false
+        },
+        {
+            "text": "Funkce \\(f\\) je definována na \\(\\mathbb{R}\\) a její derivace je kladná v každém bodě.",
+            "isCorrect": true
+        },
+        {
+            "text": "Funkce \\(f\\) je prostá.",
+            "isCorrect": true
+        }
+    ],
+    "topics": [
+        "2025-06-11-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/22588229/question.json
+++ b/questions/ma1/questions/22588229/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Které z následujících funkcí \\(f\\) nabývají svého globálního maxima na svém definičním oboru?",
+    "answers": [
+        {
+            "text": "\\( f(x)=|\\sin(x)| \\) s \\( D_f = \\langle -10,10 \\rangle \\).",
+            "isCorrect": true
+        },
+        {
+            "text": "\\( f(x)=\\tfrac{1}{x} \\) s \\( D_f = \\langle 10,100 ) \\).",
+            "isCorrect": true
+        },
+        {
+            "text": "\\( f(x)=\\ln(x) \\) s \\( D_f = (10,100) \\).",
+            "isCorrect": false
+        },
+        {
+            "text": "\\( f(x)=10-x^{40} \\) s \\( D_f = \\mathbb{R} \\).",
+            "isCorrect": true
+        }
+    ],
+    "topics": [
+        "2025-06-04-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/22891190/question.json
+++ b/questions/ma1/questions/22891190/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Nechť \\(\\left(a_n\\right)^{\\infty}_{n=1}\\) je posloupnost mající pouze kladné členy. Vyberte všechna pravdivá tvrzení.",
+    "answers": [
+        {
+            "text": "Pokud \\( \\lim_{n \\to \\infty} a_n = 0 \\),\n            potom \\( \\lim_{n \\to \\infty} \\tfrac{a_{n+1}}{a_n} < 1 \\).",
+            "isCorrect": false
+        },
+        {
+            "text": "Pokud \\( \\lim_{n \\to \\infty} \\tfrac{a_{n+1}}{a_n} > 1 \\),\n            potom \\( \\lim_{n \\to \\infty} a_n = +\\infty \\).",
+            "isCorrect": true
+        },
+        {
+            "text": "Pokud \\( \\lim_{n \\to \\infty} \\tfrac{a_{n+1}}{a_n} = 1 \\),\n            potom \\( \\lim_{n \\to \\infty} a_n \\) neexistuje.",
+            "isCorrect": false
+        },
+        {
+            "text": "Pokud \\( \\lim_{n \\to \\infty} \\tfrac{a_{n+1}}{a_n} = \\tfrac{1}{2} \\),\n            potom platí \\( \\lim_{n \\to \\infty} a_n = 0 \\).",
+            "isCorrect": true
+        }
+    ],
+    "topics": [
+        "2025-06-18-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/24999097/question.json
+++ b/questions/ma1/questions/24999097/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Nechť \\(a\\) je reálný parametr. Vyberte všechna pravdivá tvrzení o posloupnostech \\(\\left(b_n\\right)^{\\infty}_{n=1}\\) s členy \\(b_n = a^n, \\, n \\in \\mathbb{N}\\).",
+    "answers": [
+        {
+            "text": "Pokud \\(a < 0\\), pak limita posloupnosti \\(\\left(b_n\\right)^{\\infty}_{n=1}\\) neexistuje.",
+            "isCorrect": false
+        },
+        {
+            "text": "Existuje hodnota \\(a \\in \\mathbb{R}\\) pro kterou je posloupnost \\(\\left(b_n\\right)^{\\infty}_{n=1}\\) konstantní.",
+            "isCorrect": true
+        },
+        {
+            "text": "Pro \\(a = 1,\\!000\\,000\\,1\\) platí \\( \\lim_{n \\to \\infty} b_n = +\\infty \\).",
+            "isCorrect": true
+        },
+        {
+            "text": "Existuje hodnota \\(a \\in \\mathbb{R}\\) pro kterou má posloupnost \\(\\left(b_n\\right)^{\\infty}_{n=1}\\) dva hromadné body.",
+            "isCorrect": true
+        }
+    ],
+    "topics": [
+        "2025-06-18-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/28769286/question.json
+++ b/questions/ma1/questions/28769286/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Uvažme dvě funkce \\(f\\) a \\(g\\) definovaná na okolí bodu \\(a \\in \\mathbb{R}\\)\n a nechť hodnota \\(g(x)\\) je nulová pouze v bodě \\(x=a\\).\n    Vyberte všechna tvrzení pravdivá za předpokladu\n    \\[\n        \\lim_{x \\to a} f(x) = 1 \\quad \\text{a} \\quad \\lim_{x \\to a} g(x) = 0.\n    \\]",
+    "answers": [
+        {
+            "text": "\\( \\lim_{x \\to a} \\frac{f(x)}{g(x)} \\) existuje a je rovna \\(+\\infty\\) nebo \\(-\\infty\\).",
+            "isCorrect": false
+        },
+        {
+            "text": "\\( \\lim_{x \\to a} \\frac{f(x)}{g(x)^4} = +\\infty \\).",
+            "isCorrect": true
+        },
+        {
+            "text": "\\( \\lim_{x \\to a} f(x)g(x) = 0 \\).",
+            "isCorrect": true
+        },
+        {
+            "text": "\\( \\lim_{x \\to a} \\frac{f(x)}{g(x)} \\) neexistuje.",
+            "isCorrect": false
+        }
+    ],
+    "topics": [
+        "2025-06-11-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/29242872/question.json
+++ b/questions/ma1/questions/29242872/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Která z následujících tvrzení jsou pravdivá?",
+    "answers": [
+        {
+            "text": "Derivace funkce \\(\\ln\\) v bodě \\(1\\) je rovna \\(1\\).",
+            "isCorrect": true
+        },
+        {
+            "text": "Derivace funkce \\(\\ln\\) v bodě \\(2\\) je rovna \\(\\tfrac{1}{2}\\).",
+            "isCorrect": true
+        },
+        {
+            "text": "Derivace funkce \\(\\ln\\) v bodě \\(1\\) je rovna \\(0\\).",
+            "isCorrect": false
+        },
+        {
+            "text": "Derivace funkce \\(\\ln\\) v bodě \\(0\\) je rovna \\(+\\infty\\).",
+            "isCorrect": false
+        }
+    ],
+    "topics": [
+        "2025-06-04-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/30601289/question.json
+++ b/questions/ma1/questions/30601289/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Mějme dvě posloupnosti \\(\\left(a_n\\right)^{\\infty}_{n=1}\\) a \\(\\left(b_n\\right)^{\\infty}_{n=1}\\) s pouze kladnými členy. Dále předpokládejme\n    platnost vztahu \\(a_n = \\mathcal{O}(b_n)\\) pro \\(n \\to \\infty\\).\n    Vyberte všechna tvrzení, která jsou nutně pravdivá za těchto předpokladů.",
+    "answers": [
+        {
+            "text": "Existují kladná reálná konstanta \\(C\\) a přirozené číslo \\(N\\) tak,\n            že nerovnost \\(a_n < Cb_n\\) platí kdykoliv \\(n > N\\).",
+            "isCorrect": true
+        },
+        {
+            "text": "Limita \\(\\lim_{n \\to \\infty}\\ \\frac{a_n}{b_b}\\) existuje a je konečná.\n (opravdu tam bylo \\(b_b\\), asi typo?)",
+            "isCorrect": false
+        },
+        {
+            "text": "Posloupnost \\( \\left(a_n / b_n\\right)^{\\infty}_{n=1} \\) je omezená.",
+            "isCorrect": true
+        },
+        {
+            "text": "\\( b_n = \\mathcal{O}(a_n) \\) pro \\(n \\to \\infty\\)",
+            "isCorrect": false
+        }
+    ],
+    "topics": [
+        "2025-06-18-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/33509810/question.json
+++ b/questions/ma1/questions/33509810/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Mějme posloupnost \\(\\left(a_n\\right)^{\\infty}_{n=1}\\). Vyberte obecně pravdivá tvrzení.",
+    "answers": [
+        {
+            "text": "Má-li posloupnost \\(\\left(a_n\\right)^{\\infty}_{n=1}\\) limitu,\n            potom každá posloupnost vybraná z posloupnosti \\(\\left(a_n\\right)^{\\infty}_{n=1}\\) má tutéž limitu.",
+            "isCorrect": true
+        },
+        {
+            "text": "Můžeme-li z posloupnosti \\(\\left(a_n\\right)^{\\infty}_{n=1}\\) vybrat dvě různé podposloupnosti se stejnou limitou,\n            pak má limitu i posloupnost \\(\\left(a_n\\right)^{\\infty}_{n=1}\\).",
+            "isCorrect": false
+        },
+        {
+            "text": "Pokud lze z posloupnosti \\(\\left(a_n\\right)^{\\infty}_{n=1}\\) vybrat podposloupnost, která nemá limitu,\n            pak nemá limitu ani posloupnost \\(\\left(a_n\\right)^{\\infty}_{n=1}\\).",
+            "isCorrect": true
+        },
+        {
+            "text": "Pokud je posloupnost \\(\\left(a_n\\right)^{\\infty}_{n=1}\\) monotonní,\n            pak každá posloupnost z ní vybraná má limitu.",
+            "isCorrect": true
+        }
+    ],
+    "topics": [
+        "2025-06-04-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/34078704/question.json
+++ b/questions/ma1/questions/34078704/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Která z následujících tvrzení o posloupnostech a vybraných posloupnostech jsou pravdivá?",
+    "answers": [
+        {
+            "text": "Posloupnost \\(\\left(1\\right)^{\\infty}_{n=1}\\) je vybraná z posloupnosti \\(\\left(\\sin(n)\\right)^{\\infty}_{n=1}\\).",
+            "isCorrect": false
+        },
+        {
+            "text": "Posloupnost \\(\\left(\\sqrt{n}\\right)^{\\infty}_{n=1}\\) je vybraná z posloupnosti \\(\\left(n\\right)^{\\infty}_{n=1}\\).",
+            "isCorrect": false
+        },
+        {
+            "text": "Posloupnost \\(\\left(n\\right)^{\\infty}_{n=1}\\) je vybraná z posloupnosti \\(\\left(n^2\\right)^{\\infty}_{n=1}\\).",
+            "isCorrect": false
+        },
+        {
+            "text": "Posloupnost \\(\\left(n^4\\right)^{\\infty}_{n=1}\\) je vybraná z posloupnosti \\(\\left(n^2\\right)^{\\infty}_{n=1}\\).",
+            "isCorrect": true
+        }
+    ],
+    "topics": [
+        "2025-06-04-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/34888638/question.json
+++ b/questions/ma1/questions/34888638/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Pro které z následujících funkcí \\(f\\) je přímka s rovnicí \\(y=0\\) asymptotou ?",
+    "answers": [
+        {
+            "text": "\\(f(x) = \\frac{1+x}{x^2}\\).",
+            "isCorrect": true
+        },
+        {
+            "text": "\\(f(x) = \\frac{1}{\\ln(x)}\\).",
+            "isCorrect": true
+        },
+        {
+            "text": "\\(f(x) = x \\sin \\left( \\frac{1}{x} \\right) \\).",
+            "isCorrect": false
+        },
+        {
+            "text": "\\(f(x) = \\frac{\\sin x}{x}\\).",
+            "isCorrect": true
+        }
+    ],
+    "topics": [
+        "2025-06-11-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/34902168/question.json
+++ b/questions/ma1/questions/34902168/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Nechť \\(f\\) je funkce diferencovatelná na celém \\(\\mathbb{R}\\) a nechť \\(a \\in \\mathbb{R}\\).",
+    "answers": [
+        {
+            "text": "Pokud má tato funkce \\(f\\) v bodě \\(a\\) lokální extrém, potom je její derivace v bodě \\(a\\) rovna nule.",
+            "isCorrect": true
+        },
+        {
+            "text": "Pokud je \\(f\\) rostoucí na nějakém levém okolí bodu \\(a\\) a klesající na nějakém pravém okolí bodu \\(a\\),\n            pak má \\(f\\) v bodě \\(a\\) lokální minimum.",
+            "isCorrect": false
+        },
+        {
+            "text": "Pokud pro všechna \\(x \\in \\mathbb{R}\\) platí \\( f(x) \\le f(a) \\),\n            potom má funkce \\(f\\) lokální maximum v bodě \\(a\\).",
+            "isCorrect": true
+        },
+        {
+            "text": "Pokud je derivace funkce \\(f\\) v bodě \\(a\\) rovna \\(0\\) (tj. \\(f'(a)=0\\))\n            a pokud platí nerovnosti \\(f'(a-1) < 0\\) a \\(f'(a+1)>0\\),\n            potom má funkce \\(f\\) v bodě lokální minimum.",
+            "isCorrect": false
+        }
+    ],
+    "topics": [
+        "2025-06-18-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/39395786/question.json
+++ b/questions/ma1/questions/39395786/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Které z následujících funkcí \\( f \\) lze spojitě dodefinovat v uvedených bodech \\( a \\notin D_f \\) ?",
+    "answers": [
+        {
+            "text": "\\( f(x) = x \\ln|x| \\)               v bodě \\( a=0 \\).",
+            "isCorrect": true
+        },
+        {
+            "text": "\\( f(x) = \\frac{\\sin(x)}{x} \\)      v bodě \\( a=0 \\).",
+            "isCorrect": true
+        },
+        {
+            "text": "\\( f(x) = \\frac{2^x - 2}{x} \\)      v bodě \\( a=0 \\).",
+            "isCorrect": false
+        },
+        {
+            "text": "\\( f(x) = \\frac{\\cos(x)-1}{x-1} \\)  v bodě \\( a=1 \\).",
+            "isCorrect": false
+        }
+    ],
+    "topics": [
+        "2025-06-11-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/40025294/question.json
+++ b/questions/ma1/questions/40025294/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Uvažme posloupnost \\(\\left(a_n\\right)^{\\infty}_{n=1}\\) a číslo \\(\\alpha \\in \\mathbb{R}\\).\n    Vyberte všechna tvrzení ekvivalentní s tvrzením: \"limita posloupnosti \\(\\left(a_n\\right)^{\\infty}_{n=1}\\) existuje a je rovna \\(\\alpha\\)\".",
+    "answers": [
+        {
+            "text": "V každém okolí \\(U_\\alpha\\) bodu \\(\\alpha\\) leží nekonečně mnoho členů posloupnosti \\(\\left( a_n \\right)^{\\infty}_{n=1}\\).",
+            "isCorrect": false
+        },
+        {
+            "text": "Pro každé \\(\\varepsilon > 0\\) existuje \\(N \\in \\mathbb{N}\\) takové, že pro všechna přirozená \\(n\\) splňující \\(n > N\\) platí \\(|a_n - \\alpha| < \\varepsilon\\).",
+            "isCorrect": true
+        },
+        {
+            "text": "Existuje okolí \\(U_{+\\infty}\\) takové, že pro každé okolí \\(U_\\alpha\\) a každé \\(n \\in U_{+\\infty}\\) platí \\(a_n \\in U_\\alpha\\).",
+            "isCorrect": false
+        },
+        {
+            "text": "Pro každé okolí \\(U_\\alpha\\) bodu \\(\\alpha\\) existuje \\(N \\in \\mathbb{N}\\) takové, že pro všechna přirozená \\(n\\) větší než \\(N\\) patří \\(a_n\\) do množiny \\(U_\\alpha\\).",
+            "isCorrect": true
+        }
+    ],
+    "topics": [
+        "2025-06-11-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/41354902/question.json
+++ b/questions/ma1/questions/41354902/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Vyberte všechna pravdivá tvrzení",
+    "answers": [
+        {
+            "text": "Funkce \\( f(x) = \\sin(x)-x^2, \\, x \\in D_f = \\mathbb{R} \\), je ryze konkávní.",
+            "isCorrect": true
+        },
+        {
+            "text": "Funkce \\( f(x) = \\cos(x)-x, \\, x \\in D_f = \\mathbb{R} \\), je ostře klesající.",
+            "isCorrect": true
+        },
+        {
+            "text": "Funkce \\( f(x) = \\cos(2x)+2x, \\, x \\in D_f = \\mathbb{R} \\), má nekonečně mnoho lokálních extrémů.",
+            "isCorrect": false
+        },
+        {
+            "text": "Funkce \\( f(x) = \\mathrm{arctg}(x) + \\mathrm{arctg}\\left(\\frac{1}{x}\\right), \\, x \\in D_f = (0, +\\infty) \\), je konstantní na svém definičním oboru.",
+            "isCorrect": true
+        }
+    ],
+    "topics": [
+        "2025-06-11-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/44838042/question.json
+++ b/questions/ma1/questions/44838042/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Nechť \\(f\\) je funkce diferencovatelná na \\(\\mathbb{R}\\). Vyberte všechna pravdivá tvrzení.",
+    "answers": [
+        {
+            "text": "Pro každé \\(a \\in \\mathbb{R}\\) existuje konečná limita \\(\\lim_{x \\to a} f(x)\\).",
+            "isCorrect": true
+        },
+        {
+            "text": "Tečna funkce \\(f\\) v bodě \\(a\\) svírá s osou \\(x\\) úhel \\(\\alpha = \\mathrm{tg}\\big( f'(a) \\big)\\).",
+            "isCorrect": false
+        },
+        {
+            "text": "Je-li funkce \\(f\\) ostře rostoucí, potom platí nerovnost \\(f'(x) < f'(y)\\) kdykoliv \\(x < y\\).",
+            "isCorrect": false
+        },
+        {
+            "text": "Pro každé \\(b \\in \\mathbb{R}\\) existuje limita\n            \\[\n                \\lim_{h \\to 0} \\frac{f(b+h)-f(b)}{h}.\n            \\]",
+            "isCorrect": true
+        }
+    ],
+    "topics": [
+        "2025-06-18-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/45303326/question.json
+++ b/questions/ma1/questions/45303326/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Mějme funkci \\(f\\) definovanou na \\(\\mathbb{R}\\) pro níž platí \\( \\lim\\limits_{x \\to 1} f(x)=2 \\).\n    Vyberte všechna obecně pravdivá tvrzení.",
+    "answers": [
+        {
+            "text": "\\(f(1) = 2\\).",
+            "isCorrect": false
+        },
+        {
+            "text": "Je-li \\(\\left(x_n\\right)^{\\infty}_{n=1}\\) posloupnost mající limitu 1 a její členy jsou různé od 1,\n            pak \\( \\lim_{n \\to \\infty} f(x_n)=2 \\).",
+            "isCorrect": true
+        },
+        {
+            "text": "Je-li \\(\\left(x_n\\right)^{\\infty}_{n=1}\\) posloupnost mající limitu 2 a její členy jsou různé od 2,\n            pak \\( \\lim_{n \\to \\infty} f(x_n)=1 \\).",
+            "isCorrect": false
+        },
+        {
+            "text": "\\( \\lim_{n \\to \\infty} f \\left( 1 - \\frac{1}{n} \\right) = 2 \\)",
+            "isCorrect": true
+        }
+    ],
+    "topics": [
+        "2025-06-04-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/47657196/question.json
+++ b/questions/ma1/questions/47657196/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Uvažme funkci \\( f(x) = \\mathrm{e}^x + \\mathrm{e}^{-x} \\). Vyberte všechna pravdivá tvrzení.",
+    "answers": [
+        {
+            "text": "Pro každé reálné \\(x\\) platí \\(f(x) \\ge 2\\).",
+            "isCorrect": true
+        },
+        {
+            "text": "Funkce \\(f\\) je ryze konkávní na intervalu \\((-\\infty,0)\\).",
+            "isCorrect": false
+        },
+        {
+            "text": "Funkce \\(f'\\) je ryze konkávní na intervalu \\((-\\infty,0)\\).",
+            "isCorrect": true
+        },
+        {
+            "text": "Funkce \\(f\\) je ryze konvexní na celém \\(\\mathbb{R}\\).",
+            "isCorrect": true
+        }
+    ],
+    "topics": [
+        "2025-06-18-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/48789904/question.json
+++ b/questions/ma1/questions/48789904/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Nechť \\(f\\) je funkce definovaná na celém \\(\\mathbb{R}\\). Vyberte všechna pravdivá tvrzení.",
+    "answers": [
+        {
+            "text": "Pokud pro všechna kladná \\(x\\) platí \\(-1 \\le f(x) \\le 1\\),\n            potom limita \\(f\\) v \\(+\\infty\\) neexistuje.",
+            "isCorrect": false
+        },
+        {
+            "text": "Pokud má funkce \\(f\\) pouze záporné funkční hodnoty a pro všechna kladná \\(x\\) platí\n            \\( -\\tfrac{1}{x} \\le f(x) \\) potom \\( \\lim_{x \\to +\\infty} f(x) = 0 \\).",
+            "isCorrect": true
+        },
+        {
+            "text": "Pokud pro všechna \\( x \\in (-2,2) \\) platí \\( |f(x)| \\le |x| \\), potom \\( \\lim_{x \\to 0} f(x) = 0 \\).",
+            "isCorrect": true
+        },
+        {
+            "text": "Pokud pro všechna kladná \\(x\\) platí \\( f(x) \\ge -x\\),\n            potom  \\( \\lim_{x \\to +\\infty} f(x) = -\\infty \\).",
+            "isCorrect": false
+        }
+    ],
+    "topics": [
+        "2025-06-18-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/50759121/question.json
+++ b/questions/ma1/questions/50759121/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Které z následujících posloupností \\( \\left(a_n\\right)^{\\infty}_{n=1} \\) splňují vztah \\( a_n = o(n^2) \\) pro~\\( n \\to \\infty \\) ?",
+    "answers": [
+        {
+            "text": "\\( a_n = \\left( \\frac{1}{2} \\right)^n,   \\quad n \\in \\mathbb{N}. \\)",
+            "isCorrect": true
+        },
+        {
+            "text": "\\( a_n = \\sin( n^2 ),                    \\quad n \\in \\mathbb{N}. \\)",
+            "isCorrect": true
+        },
+        {
+            "text": "\\( a_n = n^2 \\ln(n),                     \\quad n \\in \\mathbb{N}. \\)",
+            "isCorrect": false
+        },
+        {
+            "text": "\\( a_n = \\sqrt[n]{n^{20}},               \\quad n \\in \\mathbb{N}. \\)",
+            "isCorrect": true
+        }
+    ],
+    "topics": [
+        "2025-06-11-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/56265534/question.json
+++ b/questions/ma1/questions/56265534/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Která z následujících tvrzení o uvedených funkcích jsou pravdivá?",
+    "answers": [
+        {
+            "text": "\\( \\sin(2x^2) = o(x) \\) pro \\(x \\to 0\\).",
+            "isCorrect": true
+        },
+        {
+            "text": "\\( 1-\\cos(x) = o(x) \\) pro \\(x \\to 0\\).",
+            "isCorrect": true
+        },
+        {
+            "text": "\\( x^3 = o(x) \\) pro \\(x \\to 0\\).",
+            "isCorrect": true
+        },
+        {
+            "text": "\\( \\sin(2x) = o(x) \\) pro \\(x \\to 0\\).",
+            "isCorrect": false
+        }
+    ],
+    "topics": [
+        "2025-06-04-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/67499765/question.json
+++ b/questions/ma1/questions/67499765/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Vyberte všechna pravdivá tvrzení.",
+    "answers": [
+        {
+            "text": "\\( \\lim_{x \\to 1} \\frac{\\sin(1-x)}{1-x} = -1 \\).",
+            "isCorrect": false
+        },
+        {
+            "text": "\\( \\lim_{x \\to 0} \\frac{2^x-1}{x} = \\ln(2) \\).",
+            "isCorrect": true
+        },
+        {
+            "text": "\\( \\lim_{x \\to 0+} x^{1/x} \\) neexistuje.",
+            "isCorrect": false
+        },
+        {
+            "text": "\\( \\lim_{x \\to +\\infty} \\left( 1 + \\frac{1}{\\sqrt{x}} \\right)^{\\sqrt{x}} = \\mathrm{e} \\).",
+            "isCorrect": true
+        }
+    ],
+    "topics": [
+        "2025-06-18-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/70360133/question.json
+++ b/questions/ma1/questions/70360133/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Která z následujících tvrzení o posloupnostech a vybraných posloupnostech jsou pravdivá ?",
+    "answers": [
+        {
+            "text": "Posloupnost \\( \\left(1\\right)^{\\infty}_{n=1} \\) je vybraná z posloupnosti \\( \\left(\\cos(\\pi n)\\right)^{\\infty}_{n=1} \\)",
+            "isCorrect": true
+        },
+        {
+            "text": "Posloupnost \\( \\left(\\frac{1}{n}\\right)^{\\infty}_{n=1} \\) je vybraná z posloupnosti \\( \\left(\\frac{1}{2n+1}\\right)^{\\infty}_{n=1} \\)",
+            "isCorrect": false
+        },
+        {
+            "text": "Posloupnost \\( \\left(\\frac{1}{2n+1}\\right)^{\\infty}_{n=1} \\) je vybraná z posloupnosti \\( \\left(\\frac{1}{n}\\right)^{\\infty}_{n=1} \\)",
+            "isCorrect": true
+        },
+        {
+            "text": "Posloupnost \\( \\left(n^2\\right)^{\\infty}_{n=1} \\) je vybraná z posloupnosti \\( \\left(n\\right)^{\\infty}_{n=1} \\)",
+            "isCorrect": true
+        }
+    ],
+    "topics": [
+        "2025-06-11-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/76753076/question.json
+++ b/questions/ma1/questions/76753076/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Které z následujících posloupností \\(\\left(a_n\\right)^{\\infty}_{n=1}\\) mají limitu rovnou Eulerovu číslu \\(\\mathrm{e}\\)?",
+    "answers": [
+        {
+            "text": "\\( a_n = \\left( 1 + \\tfrac{1}{n} \\right)^{n}, \\, n \\in \\mathbb{N} \\).",
+            "isCorrect": true
+        },
+        {
+            "text": "\\( a_n = \\left( 1 - \\tfrac{1}{n} \\right)^{-n}, \\, n \\in \\mathbb{N} \\).",
+            "isCorrect": true
+        },
+        {
+            "text": "\\( a_n = \\left( 1 + n \\right)^{1/n}, \\, n \\in \\mathbb{N} \\).",
+            "isCorrect": false
+        },
+        {
+            "text": "\\( a_n = \\left( 1 + \\tfrac{1}{\\sqrt{n}} \\right)^{\\sqrt{n}}, \\, n \\in \\mathbb{N} \\).",
+            "isCorrect": true
+        }
+    ],
+    "topics": [
+        "2025-06-04-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/76999703/question.json
+++ b/questions/ma1/questions/76999703/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Vyberte všechna tvrzení, která představují postačující podmínky pro existenci lokálního extrému funkce\n    \\(f\\) v bodě \\(4\\).",
+    "answers": [
+        {
+            "text": "Funkce \\(f\\) má v bodě \\(4\\) nulovou první derivaci a nenulovou druhou derivaci.",
+            "isCorrect": true
+        },
+        {
+            "text": "Existuje okolí \\(U_4\\) bodu \\(4\\) takové, že pro všechna \\(x\\) z tohoto okolí platí \\(f(x) \\ge f(4)\\).",
+            "isCorrect": true
+        },
+        {
+            "text": "Funkce \\(f\\) je konvexní na \\(\\mathbb{R}\\) a její tečnou v bodě \\(4\\) je přímka \\(y=5\\).",
+            "isCorrect": true
+        },
+        {
+            "text": "Funkce \\(f\\) má v bodě \\(4\\) nulovou první derivaci, nebo její derivace v tomto bodě neexistuje.",
+            "isCorrect": false
+        }
+    ],
+    "topics": [
+        "2025-06-11-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/78823315/question.json
+++ b/questions/ma1/questions/78823315/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Vyberte obecně pravdivá tvrzení o funkci \\(f\\) definované na celém \\(\\mathbb{R}\\).",
+    "answers": [
+        {
+            "text": "Pokud pro všechna kladná \\(x\\) platí nerovnosti \\( \\tfrac{1}{x} \\le f(x) \\le \\tfrac{x+1}{x} \\),\n            potom \\( \\lim_{x \\to +\\infty} f(x) \\) neexistuje.",
+            "isCorrect": false
+        },
+        {
+            "text": "Pokud pro všechna \\(x\\) z intervalu \\( (-1,1) \\) platí nerovnosti \\( 0 \\le f(x) \\le |x| \\),\n            potom \\( \\lim_{x \\to 0} f(x) = 0 \\).",
+            "isCorrect": true
+        },
+        {
+            "text": "Pokud pro všechna kladná \\(x\\) platí nerovnosti \\( f(x) \\ge -x \\),\n            potom \\( \\lim_{x \\to +\\infty} f(x) > -\\infty\\).",
+            "isCorrect": false
+        },
+        {
+            "text": "Pokud pro všechna kladná \\(x\\) platí nerovnosti \\( 0 \\le f(x) \\le \\tfrac{1}{x} \\),\n            potom \\( \\lim_{x \\to +\\infty} f(x) = 0\\).",
+            "isCorrect": true
+        }
+    ],
+    "topics": [
+        "2025-06-04-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/80306622/question.json
+++ b/questions/ma1/questions/80306622/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Mějme dvě funkce \\(f\\) a \\(g\\), které jsou diferencovatelné v bodě \\(a\\).\n    Vyberte všechna obecně pravdivá tvzrení.",
+    "answers": [
+        {
+            "text": "Derivace složené funkce \\(f \\circ g\\) v bodě \\(a\\) je rovna \\( f'(a) \\cdot g'(a) \\).",
+            "isCorrect": false
+        },
+        {
+            "text": "\\( (g \\cdot f)'(a) = g'(a)f(a) + g(a)f'(a) \\).",
+            "isCorrect": true
+        },
+        {
+            "text": "\\( \\left( \\frac{g}{f} \\right)' (a) = \\frac{g(a)f'(a)-g'(a)f(a)}{g(a)^2} \\) pokud \\(f(a) \\ne 0\\).",
+            "isCorrect": false
+        },
+        {
+            "text": "\\( \\left( \\frac{g}{f} \\right)' (a) = \\frac{g'(a)f(a)-g(a)f'(a)}{f(a)^2} \\) pokud \\(f(a) \\ne 0\\).",
+            "isCorrect": true
+        }
+    ],
+    "topics": [
+        "2025-06-04-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/90266089/question.json
+++ b/questions/ma1/questions/90266089/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Která z následujících tvrzení představují postačující podmínku pro to, aby posloupnost \\( \\left(a_n\\right)^{\\infty}_{n=1} \\) měla limitu rovnou \\(0\\) ?",
+    "answers": [
+        {
+            "text": "Pro všechna \\(n \\in \\mathbb{N}\\) platí nerovnosti \\( a_n > 0 \\) a \\( \\frac{a_{n+1}}{a_n} < 1 \\).",
+            "isCorrect": false
+        },
+        {
+            "text": "Posloupnost \\(\\left(a_n\\right)^{\\infty}_{n=1}\\) má všechny členy záporné a je ostře rostoucí.",
+            "isCorrect": false
+        },
+        {
+            "text": "Platí \\(a_n > 0\\) pro každé \\(n \\in \\mathbb{N}\\) a \\( \\lim_{n \\to \\infty} \\frac{a_{n+1}}{a_n} < 1 \\).",
+            "isCorrect": true
+        },
+        {
+            "text": "Posloupnost \\( \\left(a_n\\right)^{\\infty}_{n=1} \\) má všechny členy záporné a pro všechna \\(n \\in \\mathbb{N}\\) větší než \\(2025\\) platí nerovnost \\(a_n \\ge -\\frac{1}{n}\\).",
+            "isCorrect": true
+        }
+    ],
+    "topics": [
+        "2025-06-11-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/90745295/question.json
+++ b/questions/ma1/questions/90745295/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Vyberte všechna pravdivá tvrzení",
+    "answers": [
+        {
+            "text": "\\( \\big( 2^{-x^2} \\big)' = -x \\cdot 2^{-x^2+1} \\cdot \\ln(2) \\) pro všechna \\(x \\in \\mathbb{R}\\).",
+            "isCorrect": true
+        },
+        {
+            "text": "\\( \\big( \\mathrm{tg}(2x) \\big)' = \\tfrac{2}{\\sin^2(2x)} \\) pro všechna reálná \\(x\\),\n            která nejsou celočíselným násobkem \\( \\tfrac{\\pi}{2} \\).",
+            "isCorrect": false
+        },
+        {
+            "text": "\\( \\big( x \\ln(x) \\big)' = 1 + \\ln(x) \\) pro všechna \\(x \\in (0,+\\infty)\\).",
+            "isCorrect": true
+        },
+        {
+            "text": "\\( \\big( x\\mathrm{e}^{-x} \\big)' = (x+1)\\mathrm{e}^{-x} \\) pro všechna \\(x \\in \\mathbb{R}\\).",
+            "isCorrect": false
+        }
+    ],
+    "topics": [
+        "2025-06-18-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/96269967/question.json
+++ b/questions/ma1/questions/96269967/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Vyberte všechna pravdivá tvrzení o funkci \\( f(x) = x^3 - 3x \\).",
+    "answers": [
+        {
+            "text": "Tato funkce má maximum i minimum na libovolném intervalu \\( \\langle a,b \\rangle \\),\n tj. existují konečné hodnoty \\( \\max_{\\langle a,b \\rangle} f \\) a \\( \\min_{\\langle a,b \\rangle} f \\).",
+            "isCorrect": true
+        },
+        {
+            "text": "Minimem této funkce na intervalu \\( \\langle -\\sqrt{3}, \\sqrt{3} \\rangle \\) je 0.",
+            "isCorrect": false
+        },
+        {
+            "text": "Maximem této funkce na intervalu \\( \\langle -\\sqrt{3}, \\sqrt{3} \\rangle \\) je 2.",
+            "isCorrect": true
+        },
+        {
+            "text": "Supremum této funkce na jejím definičním oboru (tj. \\(\\mathbb{R}\\)) neexistuje.",
+            "isCorrect": false
+        }
+    ],
+    "topics": [
+        "2025-06-18-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/questions/99058070/question.json
+++ b/questions/ma1/questions/99058070/question.json
@@ -1,0 +1,25 @@
+{
+    "question": "Vyberte obecně platná tvrzení.",
+    "answers": [
+        {
+            "text": "Pokud pro \\(k,q \\in \\mathbb{R}\\) platí \\( \\lim_{x \\to +\\infty} \\big( f(x)-kx-q \\big) = 0 \\),\n            pak přímka \\(y=kx+q\\) je asymptotou funkce \\(f\\) v \\(+\\infty\\).",
+            "isCorrect": true
+        },
+        {
+            "text": "Pokud asymptotou \\(f\\) v bodě \\(a=0\\) je přímka \\(x=0\\),\n            potom platí \\( \\lim_{x \\to a} f(x) = +\\infty \\) nebo \\( \\lim_{x \\to a} f(x) = -\\infty \\).",
+            "isCorrect": false
+        },
+        {
+            "text": "Pokud platí \\( \\lim_{x \\to +\\infty} f(x) = +\\infty \\),\n            pak funkce \\(f\\) nemá asymptotu v \\(+\\infty\\).",
+            "isCorrect": false
+        },
+        {
+            "text": "Pokud platí \\( \\lim_{x \\to +\\infty} f(x) = 0 \\),\n            pak přímka \\(y=0\\) je asymptotou funkce \\(f\\) v \\(+\\infty\\).",
+            "isCorrect": true
+        }
+    ],
+    "topics": [
+        "2025-06-04-rozstrel"
+    ],
+    "questionType": "multichoice"
+}

--- a/questions/ma1/subject.json
+++ b/questions/ma1/subject.json
@@ -1,0 +1,21 @@
+{
+    "name": "Matematická Analýza 1",
+    "code": "ma1",
+    "description": "Popis ma1",
+    "primaryColor": "#1e90ff",
+    "secondaryColor": "#1565c0",
+    "topics": [
+        {
+            "id": "2025-06-04-rozstrel",
+            "name": "04.06.2025 Rozstřel"
+        },
+        {
+            "id": "2025-06-11-rozstrel",
+            "name": "11.06.2025 Rozstřel"
+        },
+        {
+            "id": "2025-06-18-rozstrel",
+            "name": "18.06.2025 Rozstřel"
+        }
+    ]
+}

--- a/web/app/components/ui/Latex.tsx
+++ b/web/app/components/ui/Latex.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import katex from "katex";
 import "katex/dist/katex.min.css";
+import renderMathInElement from "katex/contrib/auto-render";
 
 type LatexProps = {
     tex?: string | null;
@@ -16,31 +16,19 @@ export default function Latex({ tex, className }: LatexProps) {
     useEffect(() => {
         if (!containerRef.current) return;
 
-        const processLatex = (textToProcess: string) => {
-            if (!textToProcess || typeof textToProcess !== "string") return "";
+        // Vložíme text do elementu
+        containerRef.current.textContent = actualContent;
 
-            // Replace display math $$ ... $$ first
-            let processed = textToProcess.replace(/\$\$([\s\S]*?)\$\$/g, (_, math) => {
-                try {
-                    return katex.renderToString(math, { displayMode: true, throwOnError: false });
-                } catch (e) {
-                    return `$$${math}$$`;
-                }
-            });
-
-            // Then replace inline math $ ... $
-            processed = processed.replace(/\$(.*?)\$/g, (_, math) => {
-                try {
-                    return katex.renderToString(math, { displayMode: false, throwOnError: false });
-                } catch (e) {
-                    return `$${math}$`;
-                }
-            });
-
-            return processed;
-        };
-
-        containerRef.current.innerHTML = processLatex(actualContent);
+        // Necháme KaTeX automaticky najít a vykreslit matematiku
+        renderMathInElement(containerRef.current, {
+            delimiters: [
+                { left: "$$", right: "$$", display: true },
+                { left: "\\[", right: "\\]", display: true },
+                { left: "\\(", right: "\\)", display: false },
+                { left: "$", right: "$", display: false },
+            ],
+            throwOnError: false,
+        });
     }, [actualContent]);
 
     return <div ref={containerRef} className={className} />;

--- a/web/package.json
+++ b/web/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@types/katex": "^0.16.8",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",


### PR DESCRIPTION
Ahoj,

měl jsem v LaTeXu napsaný nějaký rozstřely na MA1 (https://www.overleaf.com/read/vghfbvrxsxfw#1114de), tak přidávám.

Updatnul jsem processing KaTeXu, aby kromě `$` a `$$` podporoval i `\( \)` a `\[ \]`.