### PR TITLE
fix: update correctness of answers in multiple questions

### DIFF
--- a/questions/aag/questions/50879749/question.json
+++ b/questions/aag/questions/50879749/question.json
@@ -17,10 +17,6 @@
         {
             "text": "Každá věta z jazyka má více než jeden derivační strom v nějaké gramatice generující daný jazyk.",
             "isCorrect": false
-        },
-        {
-            "text": "Nic.",
-            "isCorrect": true
         }
     ],
     "topics": [

--- a/questions/aag/questions/51257604/question.json
+++ b/questions/aag/questions/51257604/question.json
@@ -7,11 +7,11 @@
         },
         {
             "text": "Tvrzení $T$ není pravdivé, z čehož plyne, že $L$ určitě není regulární jazyk.",
-            "isCorrect": false
+            "isCorrect": true
         },
         {
             "text": "Tvrzení $T$ není pravdivé.",
-            "isCorrect": false
+            "isCorrect": true
         },
         {
             "text": "Tvrzení $T$ není pravdivé, z čehož plyne, že $L$ určitě není bezkontextový jazyk.",

--- a/questions/aag/questions/55278426/question.json
+++ b/questions/aag/questions/55278426/question.json
@@ -1,5 +1,5 @@
 {
-    "question": "Uvažujte bezkontextovou gramatiku $G = (N, \\Sigma, P, S)$. O každém z následujících tvrzení rozhodněte, zdali je pravdivé (\\checkmark) či nepravdivé (\\times):",
+    "question": "Uvažujte bezkontextovou gramatiku $G = (N, \\Sigma, P, S)$. O každém z následujících tvrzení rozhodněte, zdali je pravdivé ($\\checkmark$) či nepravdivé ($\\times$):",
     "answers": [
         {
             "text": "Zbytečným symbolem může být pouze neterminální symbol $A \\in N$. Terminální symboly $a \\in \\Sigma$ jsou vždy užitečné.",


### PR DESCRIPTION
Opravy 3 otázek, první nic interpretováno jako možnost odpovědi, druhá měla 2 špatný odpovědi a třetí špatný markup text. 